### PR TITLE
Changed hanny to handy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Github Auto Pull
 ===============================================================================
 
-This script is based on the post by [Jeffery Way](http://jeffrey-way.com/) on 
+This script is based on the post by [Jeffery Way](http://jeffrey-way.com/) on
 Nettuts+,  [The Perfect Workflow, with Git, GitHub, and SSH](http://net.tutsplus.com/tutorials/other/the-perfect-workflow-with-git-github-and-ssh/).
 
-Github Auto Pull aims to provide a secure way as possible of having your 
+Github Auto Pull aims to provide a secure way as possible of having your
 project auto pull when you push a commit to Github.
 
 
@@ -13,9 +13,9 @@ Installing
 
 1. Copy the contents of `github-pull.php` into a file on your server, you can keep the original name but for increase security you should rename it.
 
-2. Now enter the URL of your server including the path to the `github-pull.php` file (or what ever you called it) and append it with the querystring `?passgen=PASSWORD` (change PASSWORD to a random string). This will generate the salt and password for your file as well as give you the url for the service hook… which should be hany!
+2. Now enter the URL of your server including the path to the `github-pull.php` file (or what ever you called it) and append it with the querystring `?passgen=PASSWORD` (change PASSWORD to a random string). This will generate the salt and password for your file as well as give you the url for the service hook… which should be handy!
 
-3. Copy the contents of the first text box and paste that into the file (should be lines 4 and 5) 
+3. Copy the contents of the first text box and paste that into the file (should be lines 4 and 5)
 
 4. Copy the contents of the second text box and go to `https://github.com/USERNAME/PROJECT/admin/hooks` (changing USERNAME and PROJECT accordinly) and click on "Post-Receive URLs" and paste the contents into one of the empty boxes. Click "Update Settings".
 
@@ -37,7 +37,7 @@ Pass phrase you set in install step 2
 
 ###Optional
 
-`project=...` 
+`project=...`
 Give the project a name in the emails; "[PROJECT] ..."
 
 `from=...`
@@ -48,5 +48,5 @@ Who the post-pull email should go to, if empty then no email is sent
 
 
 -------------------------------------------------------------------------------
-Github Auto Pull by [Neil Sweeney](http://wolfiezero.com/) is licensed under a 
+Github Auto Pull by [Neil Sweeney](http://wolfiezero.com/) is licensed under a
 [Creative Commons Attribution-ShareAlike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/).


### PR DESCRIPTION
I think this part of the readme was supposed to say "handy" instead of "hanny"